### PR TITLE
Ignore non-upstream backport commits

### DIFF
--- a/git-tools/git-change-log
+++ b/git-tools/git-change-log
@@ -163,6 +163,14 @@ class git_change_log(object):
             self.upstream_repo = Repo(self.upstream_kernel_path)
         return self.upstream_repo
 
+    @staticmethod
+    def is_upstream_commit(commit):
+        for line in commit.message.splitlines():
+            if (re.search("Upstream status:", line, re.IGNORECASE) and
+                (re.search("RHEL", line, re.IGNORECASE) or re.search("N/A", line, re.IGNORECASE))):
+                    return False
+        return True
+
     def get_included_commits(self):
         if not hasattr(self, 'included_commits_set'):
             self.included_commits_set = set()
@@ -195,6 +203,12 @@ class git_change_log(object):
                         continue
 
                     upstream_commit = self.UpstreamRepo.commit(match.group(1))
+
+                    # Ignore refs to commits not from upstream
+                    if not git_change_log.is_upstream_commit(commit):
+                        print("Skipped (references non-upstream commit):", commit)
+                        continue
+
                     self.included_commits_set.add(upstream_commit.hexsha)
                 else:
                     if self.debug:
@@ -249,6 +263,7 @@ class git_change_log(object):
     UpstreamRepo = property(get_upstream_repo)
     IncludedCommits = property(get_included_commits)
     UpstreamCommits = property(get_upstream_commits)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Sometimes, the script will process a commit that backports a commit not from upstream and try to find the backported commit in upstream, which then fails.

Instead, search for a string indicating the backport is not from upstream, print the commit to the user, and skip it.