### PR TITLE
Ignore conflicts commit refs

### DIFF
--- a/git-tools/git-change-log
+++ b/git-tools/git-change-log
@@ -29,6 +29,7 @@ from argparse import ArgumentParser
 
 try:
     from git import Repo
+    from gitdb.exc import BadName
 except ImportError:
     print("Please Install GitPython Package (e.g. dnf install GitPython)")
     sys.exit(1)
@@ -203,6 +204,16 @@ class git_change_log(object):
                     # Ignore refs to commits not from upstream
                     if not git_change_log.is_upstream_commit(commit):
                         print("Skipped (references non-upstream commit):", commit)
+                        continue
+
+                    upstream_commit_hash = match.group(1)
+                    try:
+                        upstream_commit = self.UpstreamRepo.commit(upstream_commit_hash)
+                    except ValueError as e:
+                        print(f"Error: Commit hash {upstream_commit_hash}\n found with regex: {regex}\n referenced by commit {commit.hexsha} not found in upstream")
+                        continue
+                    except BadName as e:
+                        print(f"Error: Commit hash {upstream_commit_hash}\n found with regex: {regex}\n referenced by commit {commit.hexsha} is not a valid commit hash (maybe an issue with the regex?)")
                         continue
 
                     self.included_commits_set.add(upstream_commit.hexsha)

--- a/git-tools/git-change-log
+++ b/git-tools/git-change-log
@@ -168,14 +168,22 @@ class git_change_log(object):
                     return False
         return True
 
+    @staticmethod
+    def strip_conflicts_section(message):
+        pattern = r"^(Conflict|Conflicts):.*?\n\n"
+        filtered_message = re.sub(pattern, "", message, flags=re.DOTALL | re.MULTILINE)
+        return filtered_message
+
     def get_included_commits(self):
         if not hasattr(self, 'included_commits_set'):
             self.included_commits_set = set()
 
             for commit in self.OldRepo.iter_commits(self.old_range, paths=self.DIRS_PATHS, no_merges=True):
                 match = None
+                # Strip conflicts section so the regex doesn't find irrelevant commit hashes
+                msg_no_conflict = git_change_log.strip_conflicts_section(commit.message)
                 for regex in PICK_RGEX_LIST:
-                    match = re.search(regex, commit.message)
+                    match = re.search(regex, msg_no_conflict)
                     if match:
                         revert = "This reverts commit %s" % match.group(1)
                         if revert in commit.message:


### PR DESCRIPTION
When searching for the commit hash of the original change for a backport commit, sometimes the script will pick a commit hash referenced in the conflicts section. It's very common for the conflicts section to have
commit hashes, so ignore it when searching for the original commit hash.

Conflicts section is parsed using this regex:
r"^(Conflict|Conflicts):.*?\n\n"
    
The vast majority of Conflicts sections start with "Conflicts:", so maybe we only need to check for that.
    
Depends: https://github.com/Kamalheib/tools/pull/5
