### PR TITLE
Fix GitPython install hint to suggest pip instead of yum/dnf

### DIFF
--- a/git-tools/git-am
+++ b/git-tools/git-am
@@ -7,7 +7,7 @@ from argparse import ArgumentParser
 try:
     from git import Repo
 except ImportError:
-    print("Please Install GitPython Package (e.g. yum install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 class am(object):

--- a/git-tools/git-backport
+++ b/git-tools/git-backport
@@ -31,7 +31,7 @@ from argparse import ArgumentParser
 try:
     from git import Repo
 except ImportError:
-    print("Please Install GitPython Package (e.g. yum install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 

--- a/git-tools/git-change-log
+++ b/git-tools/git-change-log
@@ -31,7 +31,7 @@ try:
     from git import Repo
     from gitdb.exc import BadName
 except ImportError:
-    print("Please Install GitPython Package (e.g. dnf install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 SEARCH_PATHS = {

--- a/git-tools/git-cherry-pick
+++ b/git-tools/git-cherry-pick
@@ -31,7 +31,7 @@ from argparse import ArgumentParser
 try:
     from git import Repo
 except ImportError:
-    print("Please Install GitPython Package (e.g. yum install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 class cherry_pick(object):

--- a/git-tools/git-compare
+++ b/git-tools/git-compare
@@ -32,7 +32,7 @@ from argparse import ArgumentParser
 try:
     from git import Repo
 except ImportError:
-    print("Please Install GitPython Package (e.g. yum install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 class compare(object):

--- a/git-tools/git-find-fixes
+++ b/git-tools/git-find-fixes
@@ -31,7 +31,7 @@ from argparse import ArgumentParser
 try:
     from git import Repo
 except ImportError:
-    print("Please Install GitPython Package (e.g. yum install GitPython)")
+    print("Please Install GitPython Package (e.g. pip install GitPython)")
     sys.exit(1)
 
 SEARCH_PATHS = {


### PR DESCRIPTION
Update error message on GitPython ImportError to use suggested [install method](https://gitpython.readthedocs.io/en/stable/intro.html) instead of yum/dnf